### PR TITLE
Change ruby version of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.0
+  - 2.3.1
+  - 2.2.5
 env:
   - GSM_TEST_MODE=CI
 addons:


### PR DESCRIPTION
Officially support ruby `2.2.5` and `2.3.x`
